### PR TITLE
Add setlocal, update PATH with LIGHTFIELD_ROOT

### DIFF
--- a/iocs/lightFieldIOC/iocBoot/iocLightField/start_epics.bat
+++ b/iocs/lightFieldIOC/iocBoot/iocLightField/start_epics.bat
@@ -1,5 +1,7 @@
+setlocal
 start medm -x -macro "P=13LF1:, R=cam1:" LightField.adl
 call dllPath.bat
+set "PATH=%LIGHTFIELD_ROOT%;%PATH%"
 ..\..\bin\windows-x64\LightFieldApp st.cmd
 pause
 

--- a/iocs/lightFieldIOC/iocBoot/iocLightField2/start_epics.bat
+++ b/iocs/lightFieldIOC/iocBoot/iocLightField2/start_epics.bat
@@ -1,4 +1,6 @@
+setlocal
 start medm -x -macro "P=13LF2:, R=cam1:" LightField.adl
 call dllPath.bat
+set "PATH=%LIGHTFIELD_ROOT%;%PATH%"
 ..\..\bin\windows-x64-dynamic\LightFieldApp st.cmd
 


### PR DESCRIPTION
* Add setlocal to stop PATH getting too long on multiple runs of `start_epics.bat`
* Add LIGHTFIELD_ROOT to PATH to stop potential DLL issues, though it doesn't fix the current issue

I am assuming that adding LIGHTFIELD_ROOT will avoid rather than cause potential problems, but i don't have experience with the device   